### PR TITLE
Add the possibility to specify the language to use (using an ISO-639 id)

### DIFF
--- a/MRGLocale/MRGLocale.h
+++ b/MRGLocale/MRGLocale.h
@@ -17,6 +17,8 @@
 - (NSString *)localizedStringForKey:(NSString *)key;
 - (NSString *)localizedStringForKey:(NSString *)key inTable:(NSString *)tableName;
 
+- (void)setLanguageBundleWithLanguageISO639Identifier:(NSString *)languageIdentifier;
+
 + (NSString *)systemLangIdentifier;
 - (MRGDynamicLocaleRef *)currentLocaleRef;
 


### PR DESCRIPTION
Ajout de la possibilité de spécifier la langue à utiliser avec MRGString. Ceci permet donc de configurer manuellement la langue de l'application en faisant abstraction de la langue de l'appareil.
