### PR TITLE
Swift support

### DIFF
--- a/MRGLocale/MRGLocale.swift
+++ b/MRGLocale/MRGLocale.swift
@@ -1,0 +1,13 @@
+//
+//  MRGLocale.swift
+//  MRGLocale
+//
+//  Created by Daniel Levesque on 2015-03-18.
+//  Copyright (c) 2015 Mirego. All rights reserved.
+//
+
+import Foundation
+
+func MRGString(key:String) -> String {
+    return MRGLocale.sharedInstance().localizedStringForKey(key)
+}


### PR DESCRIPTION
Allows to use `MGRString("string_key")` in swift code.
